### PR TITLE
handle dayname and day number

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -147,7 +147,7 @@ export default class Vreme {
       }
 
       // Otherwise reset object
-      this.reset()
+      this._reset()
 
       // Then call the function again
       return bestMatch(number, date)
@@ -168,19 +168,16 @@ export default class Vreme {
 
     // Check if format string is full day name
     if (format.match(this.regex.DAYNAMES_REGEXP)) {
-      this.matches.day = true
       return this._correctCase(format, this.options.dayNames[date.getDay()])
     }
 
     // Check if format string is 3 letter day name
     if (format.match(this.regex.DAYNAMES_ABBR_REGEXP)) {
-      this.matches.day = true
       return this._correctCase(format, this.options.dayNames[date.getDay()].substr(0, 3))
     }
 
     // Check if format string is 2 letter day name
     if (format.match(this.regex.DAYNAMES_SHORT_REGEXP)) {
-      this.matches.day = true
       return this._correctCase(format, this.options.dayNames[date.getDay()].substr(0, 2))
     }
 
@@ -219,7 +216,7 @@ export default class Vreme {
       let number = parseInt(format, 10)
 
       // And try to find the best match (it could be month, day or maybe year,
-      // but that's a bit unlikelly)
+      // but that's a bit unlikely)
       return bestMatch(number, date)
     }
 

--- a/test/index.js
+++ b/test/index.js
@@ -91,6 +91,8 @@ describe('Human Readable Time format', () => {
 
     it('should format date in Monthname D, YYYY H:MM am/pm format', () => expect(stamp.format(date, 'March 25, 1999 2:04 PM')).to.equal('August 01, 2015 2:10 AM'))
 
+    it('should format date in Dayname M/D/YY format', () => expect(stamp.format(date, 'Tue 2/9/90')).to.equal('Sat 8/1/15'))
+
     it('should keep the extraneous text', () => expect(stamp.format(date, 'Date: March, 25th')).to.equal('Date: August, 1st'))
 
     it('should keep the extraneous text after time', () => expect(stamp.format(date, 'Date: March, 25th 1:10pm lorem ipsum')).to.equal('Date: August, 1st 2:10am lorem ipsum'))


### PR DESCRIPTION
Couldn't handle eg `Tue 2/4/90`. Basically it shouldn't matter that it's already seen a dayname (eg `Tue`) when interpreting the numeric fields